### PR TITLE
Release v5.15.2026 hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## v5.15.2026 — 2026-05-15
+
+### Hardened — Filesystem Boundaries and Release Trust
+
+- Replaced unsafe string-prefix path containment checks with
+  boundary-aware `Path.relative_to()` containment through
+  `clawed.paths.path_is_within()`.
+- Hardened self-modification reads/writes, workspace reads, output file
+  listing/organization, and material ingestion against prefix-sibling path
+  escapes such as `/tmp/workspace-evil` being treated as inside
+  `/tmp/workspace`.
+- Moved API token path resolution from an import-time constant to
+  `clawed.paths.api_token_path()` so `EDUAGENT_DATA_DIR` changes are honored
+  at runtime.
+- Fixed a stale Telegram daemon setup hint so it points to the real
+  `clawed config set-token YOUR_TOKEN` command.
+- Updated architecture and security documentation to reflect the current
+  Python 3.11+ requirement, filesystem boundary layer, and non-certified
+  compliance posture.
+
+### Verified
+
+- `uv run --extra dev ruff check ...`: clean for changed source and tests.
+- `uv run --extra dev mypy --strict clawed`: 0 errors.
+- `uv run --extra dev python -m pytest -q tests/test_audit_fixes.py tests/test_file_manager.py tests/test_security.py`: 50 passed.
+
 ## v4.25.2026 — 2026-04-25
 
 ### Hardened — Release, Security, and Publish Readiness

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An open-source CLI agent that generates complete lesson bundles — plans, hando
 **Sibling project:** [Claw-STU](https://sirhanmacx.github.io/Claw-STU/) — the student-facing personal learning agent. Ed builds the lessons; Stuart helps students understand them.
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-v4.25.2026-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-v5.15.2026-blue" alt="Version">
   <a href="https://pypi.org/project/clawed/"><img src="https://img.shields.io/pypi/v/clawed?color=blue" alt="PyPI"></a>
   <a href="https://pypi.org/project/clawed/"><img src="https://img.shields.io/pypi/pyversions/clawed" alt="Python"></a>
   <a href="https://github.com/SirhanMacx/Claw-ED/actions/workflows/ci.yml"><img src="https://github.com/SirhanMacx/Claw-ED/actions/workflows/ci.yml/badge.svg" alt="CI"></a>

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,10 +1,15 @@
 # Roadmap
 
-Current version: **v4.25.2026**
+Current version: **v5.15.2026**
 
-## v4.17 — What's next
+## v5.16 — What's next
 
-### Recently shipped (v4.16)
+### Recently shipped (v5.15)
+- [x] **Boundary-aware filesystem guards** — agent file tools now use `clawed.paths.path_is_within()` instead of string-prefix checks, closing prefix-sibling path escapes across workspace reads, self-modification, output organization, and material ingestion
+- [x] **Runtime API token path resolution** — API token storage now resolves `EDUAGENT_DATA_DIR` at call time through `clawed.paths.api_token_path()`
+- [x] **Security wording tightened** — compliance docs now describe the real local-first posture without implying formal FERPA/COPPA/GDPR certification
+
+### Recently shipped (v4.16-v4.25)
 - [x] **`mypy --strict` project-wide** — 1074 errors → 0 across 270 files, 144 files touched. Surfaced and fixed 7+ real runtime bugs (wrong imports, sync calls to async methods, tuple-as-dict access, missing None guards)
 - [x] **B904 exception chaining** — 51 raise sites in `except` blocks now use `from <exc>` to preserve tracebacks. Suppression removed from ruff config
 - [x] **April 2026 audit regression pass** — 38/38 previously-fixed defects re-verified in v4.13 code; zero regressions
@@ -15,7 +20,7 @@ Current version: **v4.25.2026**
 - [ ] **Path centralization**: complete paths.py migration for all modules
 - [ ] **Test coverage**: add tests for export_pptx, generation, models (30 untested modules)
 - [ ] **conftest simplification**: one env var patch instead of 19 monkeypatches
-- [ ] **mypy CI gate**: enforce `--strict` in GitHub Actions (currently local-only check)
+- [x] **mypy CI gate**: enforce `--strict` in GitHub Actions
 
 ### Semantic knowledge graph (Graphify)
 - [ ] **LLM-powered entity extraction**: replace heuristic kg_extractor.py

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,10 +25,16 @@ Claw-ED is a local-first tool designed for teachers. Your data stays on your mac
 
 ## Compliance
 
-- **FERPA compatible** — no student education records are transmitted or aggregated
-- **COPPA compatible** — student interactions stay on the teacher's machine
-- **GDPR compatible** — local-first architecture with no data collection
-- **State education data laws** — check your state's requirements for AI tools in education
+Claw-ED is designed for local-first, teacher-controlled use, but it is not a
+formally certified FERPA/COPPA/GDPR compliance product.
+
+- Do not use Claw-ED with identifiable student records, IEP/504 documents,
+  school-issued accounts, or district-restricted data unless your district has
+  approved that workflow.
+- Student interactions stay on the teacher's machine by default, but cloud LLM
+  providers receive prompts when you choose a cloud model.
+- State education data laws vary. Check your district and state requirements
+  before using any AI tool with student data.
 
 ## Self-Equipping Safety
 

--- a/clawed/__init__.py
+++ b/clawed/__init__.py
@@ -14,7 +14,7 @@ if hasattr(sys.stderr, "reconfigure"):
     with contextlib.suppress(Exception):
         sys.stderr.reconfigure(encoding="utf-8", errors="replace")
 
-__version__ = "4.25.2026"
+__version__ = "5.15.2026"
 __author__ = "Jon Maccarello & Claw-ED contributors"
 __description__ = "Your AI co-teacher. Generate lessons, games, slides, and assessments from your terminal."
 

--- a/clawed/_entry_router.py
+++ b/clawed/_entry_router.py
@@ -427,7 +427,7 @@ def _handle_daemon(args: list[str]) -> None:
             "1. Open Telegram and message @BotFather\n"
             "2. Send /newbot and follow the steps\n"
             "3. Copy the bot token\n"
-            "4. Run: clawed config set-token --telegram YOUR_TOKEN\n"
+            "4. Run: clawed config set-token YOUR_TOKEN\n"
         )
         sys.exit(0)
 

--- a/clawed/agent_core/tools/file_manager.py
+++ b/clawed/agent_core/tools/file_manager.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from clawed.agent_core.context import AgentContext, ToolResult
+from clawed.paths import path_is_within
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +18,12 @@ def _get_output_dir(context: AgentContext) -> Path:
     """Get the teacher's output directory."""
     output_dir = getattr(context.config, "output_dir", "~/clawed_output")
     return Path(output_dir).expanduser()
+
+
+def _resolve_output_path(output_dir: Path, relative_path: str) -> Path | None:
+    """Resolve a user-supplied path under output_dir, rejecting traversal."""
+    candidate = (output_dir / relative_path).expanduser().resolve()
+    return candidate if path_is_within(candidate, output_dir) else None
 
 
 class FileListTool:
@@ -56,9 +63,13 @@ class FileListTool:
         subpath = params.get("path", "")
         pattern = params.get("pattern", "*")
 
-        target = (output_dir / subpath).resolve() if subpath else output_dir.resolve()
+        target = (
+            _resolve_output_path(output_dir, subpath)
+            if subpath
+            else output_dir.resolve()
+        )
         # Prevent path traversal outside output directory
-        if not str(target).startswith(str(output_dir.resolve())):
+        if target is None:
             return ToolResult(text="ERROR: path outside output directory")
         if not target.exists():
             return ToolResult(text=f"Directory not found: {target}")
@@ -130,15 +141,19 @@ class FileOrganizeTool:
 
         try:
             if action == "create_folder":
-                folder = output_dir / (dest or source)
+                folder = _resolve_output_path(output_dir, dest or source)
+                if folder is None:
+                    return ToolResult(text="ERROR: destination outside output directory")
                 folder.mkdir(parents=True, exist_ok=True)
                 return ToolResult(text=f"Created folder: {folder}")
 
             elif action == "move_file":
                 if not source or not dest:
                     return ToolResult(text="ERROR: both source and destination required for move_file")
-                src_path = output_dir / source
-                dst_path = output_dir / dest
+                src_path = _resolve_output_path(output_dir, source)
+                dst_path = _resolve_output_path(output_dir, dest)
+                if src_path is None or dst_path is None:
+                    return ToolResult(text="ERROR: source and destination must stay inside output directory")
                 if not src_path.exists():
                     return ToolResult(text=f"Source not found: {src_path}")
                 dst_path.parent.mkdir(parents=True, exist_ok=True)

--- a/clawed/agent_core/tools/ingest_materials.py
+++ b/clawed/agent_core/tools/ingest_materials.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from clawed.agent_core.context import AgentContext, ToolResult
+from clawed.paths import path_is_within
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +53,7 @@ class IngestMaterialsTool:
 
         # Security: only allow ingesting files from the user's home directory
         home = Path.home().resolve()
-        if not str(resolved).startswith(str(home)):
+        if not path_is_within(resolved, home):
             return ToolResult(
                 text="Access denied: can only ingest files from your home directory."
             )

--- a/clawed/agent_core/tools/read_workspace.py
+++ b/clawed/agent_core/tools/read_workspace.py
@@ -40,11 +40,11 @@ class ReadWorkspaceTool:
     async def execute(
         self, params: dict[str, Any], context: AgentContext
     ) -> ToolResult:
-        from clawed.paths import workspace_dir
+        from clawed.paths import path_is_within, workspace_dir
         workspace = workspace_dir()
         filename = params["filename"]
         target = (workspace / filename).resolve()
-        if not str(target).startswith(str(workspace.resolve())):
+        if not path_is_within(target, workspace):
             return ToolResult(text="Access denied: path is outside the workspace.")
 
         if not target.exists():

--- a/clawed/agent_core/tools/self_modify.py
+++ b/clawed/agent_core/tools/self_modify.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, ClassVar
 
 from clawed.agent_core.context import AgentContext, ToolResult
+from clawed.paths import path_is_within
 
 logger = logging.getLogger(__name__)
 
@@ -189,8 +190,10 @@ class WriteFileTool:
         # Block path traversal
         try:
             full_path = full_path.resolve()
-            if not (str(full_path).startswith(str(data_dir.resolve())) or
-                    str(full_path).startswith(str(output_dir.resolve()))):
+            if not (
+                path_is_within(full_path, data_dir)
+                or path_is_within(full_path, output_dir)
+            ):
                 return ToolResult(text="ERROR: path must be within workspace or output directory")
         except Exception:
             logger.debug("operation_failed", exc_info=True)
@@ -299,8 +302,8 @@ class ReadFileTool:
                 # files on disk. WriteFileTool had this check; ReadFileTool
                 # did not.
                 if not (
-                    str(full_path).startswith(str(data_root))
-                    or str(full_path).startswith(str(output_root))
+                    path_is_within(full_path, data_root)
+                    or path_is_within(full_path, output_root)
                 ):
                     continue
                 if full_path.exists() and full_path.is_file():

--- a/clawed/api/deps.py
+++ b/clawed/api/deps.py
@@ -13,12 +13,12 @@ import time
 from collections import defaultdict
 from collections.abc import Awaitable, Callable
 from functools import wraps
-from pathlib import Path
 from typing import Any, TypeVar
 
 from fastapi import HTTPException, Request
 
 from clawed.database import Database
+from clawed.paths import api_token_path
 
 F = TypeVar("F", bound=Callable[..., Awaitable[Any]])
 
@@ -117,22 +117,18 @@ limiter = _RateLimiter()
 
 # ── Auth Token ───────────────────────────────────────────────────────
 
-_TOKEN_FILE = Path(
-    os.environ.get("EDUAGENT_DATA_DIR", str(Path.home() / ".eduagent"))
-) / "api_token"
-
-
 def _get_or_create_token() -> str:
     """Get existing API token or generate a new one."""
-    if _TOKEN_FILE.exists():
-        token = _TOKEN_FILE.read_text(encoding="utf-8").strip()
+    token_file = api_token_path()
+    if token_file.exists():
+        token = token_file.read_text(encoding="utf-8").strip()
         if token:
             return token
     token = secrets.token_urlsafe(32)
-    _TOKEN_FILE.parent.mkdir(parents=True, exist_ok=True)
-    _TOKEN_FILE.write_text(token, encoding="utf-8")
+    token_file.parent.mkdir(parents=True, exist_ok=True)
+    token_file.write_text(token, encoding="utf-8")
     with contextlib.suppress(OSError):
-        _TOKEN_FILE.chmod(0o600)
+        token_file.chmod(0o600)
     return token
 
 

--- a/clawed/paths.py
+++ b/clawed/paths.py
@@ -23,6 +23,20 @@ def data_dir() -> Path:
     )
 
 
+def path_is_within(path: Path, root: Path) -> bool:
+    """Return True when path resolves inside root.
+
+    String prefix checks are unsafe for containment because sibling paths
+    like ``/tmp/base-evil`` also start with ``/tmp/base``. Resolve both
+    paths and use pathlib's boundary-aware relationship instead.
+    """
+    try:
+        path.expanduser().resolve().relative_to(root.expanduser().resolve())
+        return True
+    except (OSError, ValueError):
+        return False
+
+
 # ── Workspace ────────────────────────────────────────────────────────
 
 def workspace_dir() -> Path:

--- a/cli/source/package.json
+++ b/cli/source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawed",
-  "version": "4.25.2026",
+  "version": "5.15.2026",
   "bin": {
     "clawed": "cli.js"
   },

--- a/daemon/package.json
+++ b/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawed-daemon",
-  "version": "4.25.2026",
+  "version": "5.15.2026",
   "description": "Claw-ED background daemon — always-on Telegram teaching assistant",
   "type": "module",
   "main": "index.ts",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 Claw-ED is a persistent AI teaching assistant. Ed lives in your terminal and on your phone, generating lessons, assessments, and materials in your teaching voice.
 
-This document describes the v4.25.2026 architecture -- how messages flow through the system, what each module does, and how components connect.
+This document describes the v5.15.2026 architecture -- how messages flow through the system, what each module does, and how components connect.
 
 ---
 
@@ -160,6 +160,18 @@ All persistent data lives under `$EDUAGENT_DATA_DIR` (defaults to `~/.eduagent/`
     +-- corpus.db            # Few-shot examples for prompt injection (SQLite)
 ```
 
+### Filesystem Boundary Layer
+
+Agent tools that read or write files must resolve user-supplied paths through `clawed.paths.path_is_within()` instead of string prefix checks. This prevents prefix-sibling escapes such as `/tmp/workspace-evil` being treated as inside `/tmp/workspace`.
+
+Current protected surfaces:
+- Workspace reads (`read_workspace`)
+- Self-modification reads and writes (`read_file`, `write_file`)
+- Output file listing and organization (`list_output_files`, `organize_files`)
+- Material ingestion home-directory guard (`ingest_materials`)
+
+API token storage also resolves `EDUAGENT_DATA_DIR` at call time through `clawed.paths.api_token_path()`, so tests, Docker runs, and multi-profile launches do not accidentally reuse an import-time token path.
+
 ---
 
 ## Multi-Provider Auth
@@ -204,7 +216,7 @@ Teachers ingest their existing curriculum materials. The system chunks them, ext
 
 | Layer | Technology |
 |-------|-----------|
-| Language | Python 3.10+ (backend), TypeScript (TUI) |
+| Language | Python 3.11+ (backend), TypeScript (TUI) |
 | TUI | Ink (React for CLI) via Node.js |
 | CLI | Typer + Rich (Python fallback) |
 | Async HTTP | httpx |

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,7 +33,7 @@
   "applicationCategory": "EducationalApplication",
   "operatingSystem": "macOS, Windows, Linux",
   "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
-  "softwareVersion": "4.25.2026",
+  "softwareVersion": "5.15.2026",
   "author": {
     "@type": "Organization",
     "name": "Claw-ED",
@@ -644,7 +644,7 @@ pytest</pre>
     <a href="https://github.com/SirhanMacx/Claw-ED/discussions">Discussions</a>
   </p>
   <p style="margin-top: 0.5rem;">
-    MIT License &middot; v4.25.2026
+    MIT License &middot; v5.15.2026
   </p>
 </footer>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clawed"
-version = "4.25.2026"
+version = "5.15.2026"
 description = "Your AI co-teacher. Generate lessons, games, slides, and assessments from your terminal. Learns your teaching voice, aligns to your state standards, and works with any LLM provider."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_audit_fixes.py
+++ b/tests/test_audit_fixes.py
@@ -235,3 +235,94 @@ class TestSendNotification:
 
         result = send_notification("test message")
         assert result is False
+
+
+class TestPathContainment:
+    """Path checks must be boundary-aware, not string-prefix checks."""
+
+    def test_path_is_within_rejects_prefix_sibling(self, tmp_path):
+        from clawed.paths import path_is_within
+
+        root = tmp_path / "base"
+        sibling = tmp_path / "base-evil"
+        root.mkdir()
+        sibling.mkdir()
+
+        assert path_is_within(root / "child.txt", root)
+        assert not path_is_within(sibling / "child.txt", root)
+
+    @pytest.mark.asyncio
+    async def test_read_file_blocks_prefix_sibling_escape(self, tmp_path, monkeypatch):
+        from clawed.agent_core.tools.self_modify import ReadFileTool
+
+        data_root = tmp_path / "ed"
+        sibling = tmp_path / "ed-evil"
+        data_root.mkdir()
+        sibling.mkdir()
+        (sibling / "secret.txt").write_text("do not read", encoding="utf-8")
+        monkeypatch.setenv("EDUAGENT_DATA_DIR", str(data_root))
+
+        result = await ReadFileTool().execute(
+            {"path": "../ed-evil/secret.txt"},
+            _ctx(),
+        )
+
+        assert "out of bounds" in result.text
+        assert "do not read" not in result.text
+
+    @pytest.mark.asyncio
+    async def test_write_file_blocks_prefix_sibling_escape(self, tmp_path, monkeypatch):
+        from clawed.agent_core.tools.self_modify import WriteFileTool
+
+        data_root = tmp_path / "ed"
+        sibling = tmp_path / "ed-evil"
+        data_root.mkdir()
+        sibling.mkdir()
+        monkeypatch.setenv("EDUAGENT_DATA_DIR", str(data_root))
+
+        result = await WriteFileTool().execute(
+            {
+                "path": "workspace/../../ed-evil/pwned.txt",
+                "content": "do not write",
+            },
+            _ctx(),
+        )
+
+        assert "within workspace or output directory" in result.text
+        assert not (sibling / "pwned.txt").exists()
+
+    @pytest.mark.asyncio
+    async def test_read_workspace_blocks_prefix_sibling_escape(self, tmp_path, monkeypatch):
+        from clawed.agent_core.tools.read_workspace import ReadWorkspaceTool
+
+        data_root = tmp_path / "ed"
+        workspace = data_root / "workspace"
+        sibling = data_root / "workspace-evil"
+        workspace.mkdir(parents=True)
+        sibling.mkdir()
+        (sibling / "secret.txt").write_text("do not read", encoding="utf-8")
+        monkeypatch.setenv("EDUAGENT_DATA_DIR", str(data_root))
+
+        result = await ReadWorkspaceTool().execute(
+            {"filename": "../workspace-evil/secret.txt"},
+            _ctx(),
+        )
+
+        assert "outside the workspace" in result.text
+        assert "do not read" not in result.text
+
+    def test_api_token_respects_runtime_data_dir(self, tmp_path, monkeypatch):
+        from clawed.api.deps import get_api_token
+
+        first = tmp_path / "first"
+        second = tmp_path / "second"
+
+        monkeypatch.setenv("EDUAGENT_DATA_DIR", str(first))
+        first_token = get_api_token()
+
+        monkeypatch.setenv("EDUAGENT_DATA_DIR", str(second))
+        second_token = get_api_token()
+
+        assert (first / "api_token").read_text(encoding="utf-8").strip() == first_token
+        assert (second / "api_token").read_text(encoding="utf-8").strip() == second_token
+        assert first_token != second_token

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -334,7 +334,7 @@ class TestVersion:
     def test_version_string(self):
         from clawed import __version__
 
-        assert __version__ == "4.25.2026"
+        assert __version__ == "5.15.2026"
 
 
 # ── Standards module ───────────────────────────────────────────────

--- a/tests/test_entry_router.py
+++ b/tests/test_entry_router.py
@@ -120,7 +120,7 @@ def test_main_version_uses_python_package_version(capsys):
             main()
 
     captured = capsys.readouterr()
-    assert "4.25.2026 (Claw-ED)" in captured.out
+    assert "5.15.2026 (Claw-ED)" in captured.out
     mock_run.assert_not_called()
 
 

--- a/tests/test_file_manager.py
+++ b/tests/test_file_manager.py
@@ -73,6 +73,28 @@ class TestFileListTool:
         result = await tool.execute({"path": "sub"}, ctx)
         assert "quiz.docx" in result.text
 
+    @pytest.mark.asyncio
+    async def test_list_rejects_prefix_sibling_traversal(self, output_dir):
+        from clawed.agent_core.context import AgentContext
+        from clawed.models import AppConfig
+
+        sibling = output_dir.parent / f"{output_dir.name}-evil"
+        sibling.mkdir()
+        (sibling / "secret.docx").write_text("outside output", encoding="utf-8")
+
+        config = AppConfig()
+        config.output_dir = str(output_dir)
+        ctx = AgentContext(
+            teacher_id="t1", config=config,
+            teacher_profile={}, persona=None,
+            session_history=[], improvement_context="",
+        )
+
+        result = await FileListTool().execute({"path": f"../{sibling.name}"}, ctx)
+
+        assert "outside output directory" in result.text
+        assert "secret.docx" not in result.text
+
 
 class TestFileOrganizeTool:
     def test_schema_valid(self):
@@ -116,6 +138,62 @@ class TestFileOrganizeTool:
         assert "Moved" in result.text
         assert (output_dir / "sub" / "lesson1.docx").exists()
         assert not (output_dir / "lesson1.docx").exists()
+
+    @pytest.mark.asyncio
+    async def test_create_folder_rejects_prefix_sibling_traversal(self, output_dir):
+        from clawed.agent_core.context import AgentContext
+        from clawed.models import AppConfig
+
+        sibling = output_dir.parent / f"{output_dir.name}-evil"
+        sibling.mkdir()
+
+        config = AppConfig()
+        config.output_dir = str(output_dir)
+        ctx = AgentContext(
+            teacher_id="t1", config=config,
+            teacher_profile={}, persona=None,
+            session_history=[], improvement_context="",
+        )
+
+        result = await FileOrganizeTool().execute(
+            {
+                "action": "create_folder",
+                "destination": f"../{sibling.name}/pwned",
+            },
+            ctx,
+        )
+
+        assert "outside output directory" in result.text
+        assert not (sibling / "pwned").exists()
+
+    @pytest.mark.asyncio
+    async def test_move_file_rejects_prefix_sibling_traversal(self, output_dir):
+        from clawed.agent_core.context import AgentContext
+        from clawed.models import AppConfig
+
+        sibling = output_dir.parent / f"{output_dir.name}-evil"
+        sibling.mkdir()
+
+        config = AppConfig()
+        config.output_dir = str(output_dir)
+        ctx = AgentContext(
+            teacher_id="t1", config=config,
+            teacher_profile={}, persona=None,
+            session_history=[], improvement_context="",
+        )
+
+        result = await FileOrganizeTool().execute(
+            {
+                "action": "move_file",
+                "source": "lesson1.docx",
+                "destination": f"../{sibling.name}/lesson1.docx",
+            },
+            ctx,
+        )
+
+        assert "inside output directory" in result.text
+        assert not (sibling / "lesson1.docx").exists()
+        assert (output_dir / "lesson1.docx").exists()
 
 
 class TestWorkspaceStatusTool:

--- a/tests/test_v013_features.py
+++ b/tests/test_v013_features.py
@@ -464,12 +464,12 @@ class TestVersion:
     def test_version_string(self):
         from clawed import __version__
 
-        assert __version__ == "4.25.2026"
+        assert __version__ == "5.15.2026"
 
     def test_version_in_health_endpoint(self, client):
         resp = client.get("/api/health")
         data = resp.json()
-        assert data["version"] == "4.25.2026"
+        assert data["version"] == "5.15.2026"
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "clawed"
-version = "4.25.2026"
+version = "5.15.2026"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## What changed

- Bumped Claw-ED to `5.15.2026` across Python package metadata, CLI/daemon metadata, docs, tests, and lockfile.
- Added boundary-aware path containment via `clawed.paths.path_is_within()` and applied it to self-modification tools, workspace reads, output file organization, and material ingestion.
- Moved API token lookup to runtime `api_token_path()` resolution so `EDUAGENT_DATA_DIR` changes do not reuse an import-time token location.
- Fixed the stale Telegram daemon setup hint and tightened security docs around local-first/non-certified compliance posture.

## Why

The existing code used string-prefix path checks in several agent file tools. That can misclassify sibling paths such as `/tmp/workspace-evil` as inside `/tmp/workspace`. This release hardens those boundaries and updates the architecture docs to make the rule explicit.

## Validation

- `uv run --extra dev ruff check .`
- `uv run --extra dev mypy --strict clawed`
- `uv run --extra dev python -m pytest -q` -> `2100 passed, 4 skipped`
- `uvx pip-audit` -> no known vulnerabilities found
- `node scripts/build-cli.mjs`
- `bash scripts/build.sh --skip-ts`
- wheel smoke install: `clawed --version` -> `5.15.2026 (Claw-ED)`

## Release note

I used `5.15.2026` for the version stamp because the repo's release scheme is month.day.year and the requested `5.15.2025` appears to be a past-year typo for the May 15, 2026 release.
