### PR TITLE
Add MacxLabs README support link

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,6 @@ COPY pyproject.toml README.md ./
 COPY clawed/ clawed/
 COPY eduagent/ eduagent/
 
-# Create empty CLI bundle dir (hatchling requires it)
-RUN mkdir -p clawed/_cli_bundle && \
-    echo '{"type":"module"}' > clawed/_cli_bundle/package.json
-
 # Non-editable install, base deps only
 RUN pip install --no-cache-dir .
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ An open-source CLI agent that generates complete lesson bundles — plans, hando
 
 **Sibling project:** [Claw-STU](https://sirhanmacx.github.io/Claw-STU/) — the student-facing personal learning agent. Ed builds the lessons; Stuart helps students understand them.
 
+Claw-ED is maintained as part of [MacxLabs](https://macxlabs.app/?src=github-claw-ed-readme). If it saves you prep time, [support us here](https://macxlabs.app/support/?src=github-claw-ed-readme).
+
 <p align="center">
   <img src="https://img.shields.io/badge/version-v5.15.2026-blue" alt="Version">
   <a href="https://pypi.org/project/clawed/"><img src="https://img.shields.io/pypi/v/clawed?color=blue" alt="PyPI"></a>


### PR DESCRIPTION
## Summary
- add a quiet MacxLabs support sentence to the README
- route the support CTA to the MacxLabs support page, not directly to Stripe
- remove the Dockerfile-generated CLI bundle package.json that caused Hatch to add the same wheel path twice during docker-build

## Revenue note
This keeps Claw-ED's product flow unchanged while giving interested repo visitors a passive way to support MacxLabs.

## Test
- git diff --check
- verified README contains the support link
- verified https://macxlabs.app/support/?src=github-claw-ed-readme returns 200
- docker build could not be run locally because Docker is not installed in this environment; PR CI is the authoritative docker-build check