### PR TITLE
ci: fall back when ONNX model is unavailable

### DIFF
--- a/clawed/agent_core/memory/embeddings.py
+++ b/clawed/agent_core/memory/embeddings.py
@@ -10,7 +10,6 @@ Produces 384-dimensional dense vectors — compact, fast, high quality.
 """
 from __future__ import annotations
 
-import json
 import logging
 import math
 import os
@@ -32,6 +31,8 @@ _TOKENIZER_URL = (
     "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/"
     "resolve/main/tokenizer.json"
 )
+
+_ONNX_UNAVAILABLE = False
 
 
 # ── ONNX MiniLM Embedder ────────────────────────────────────────────
@@ -315,18 +316,21 @@ def get_embedder() -> ONNXMiniLMEmbedder | OllamaEmbedder | TFIDFEmbedder:
     Priority: ONNX MiniLM > Ollama (local) > TF-IDF fallback.
     """
     # 1. ONNX MiniLM — best quality, offline, 384-dim
-    try:
-        import numpy  # noqa: F401
-        import onnxruntime  # noqa: F401
-        import tokenizers  # noqa: F401
-        embedder = ONNXMiniLMEmbedder()
-        if embedder._ensure_model():
-            return embedder
-        logger.debug("ONNX MiniLM model not yet downloaded, will try on next use")
-        # Return it anyway — it'll download on first embed() call
-        return embedder
-    except ImportError:
-        pass
+    global _ONNX_UNAVAILABLE
+    if not _ONNX_UNAVAILABLE:
+        try:
+            import numpy  # noqa: F401
+            import onnxruntime  # noqa: F401
+            import tokenizers  # noqa: F401
+            embedder = ONNXMiniLMEmbedder()
+            if embedder._ensure_model():
+                return embedder
+            _ONNX_UNAVAILABLE = True
+            logger.warning(
+                "ONNX MiniLM model unavailable; using fallback embedder for this process"
+            )
+        except ImportError:
+            _ONNX_UNAVAILABLE = True
 
     # 2. Ollama (local server with embedding model)
     try:
@@ -338,8 +342,8 @@ def get_embedder() -> ONNXMiniLMEmbedder | OllamaEmbedder | TFIDFEmbedder:
             if embed_models:
                 logger.debug("Using Ollama embedder: %s", embed_models[0])
                 return OllamaEmbedder(model=embed_models[0])
-    except (json.JSONDecodeError, KeyError):
-        pass
+    except Exception as e:
+        logger.debug("Ollama embedder unavailable: %s", e)
 
     # 3. TF-IDF fallback
     logger.debug(

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -63,6 +63,26 @@ class TestCurriculumStateLayer:
 
 
 class TestEmbeddingProvider:
+    def test_falls_back_when_onnx_model_unavailable(self, monkeypatch):
+        from clawed.agent_core.memory import embeddings
+
+        attempts = {"count": 0}
+
+        def fail_onnx(_self):
+            attempts["count"] += 1
+            return False
+
+        def fail_ollama(*_args, **_kwargs):
+            raise RuntimeError("ollama unavailable")
+
+        monkeypatch.setattr(embeddings, "_ONNX_UNAVAILABLE", False)
+        monkeypatch.setattr(embeddings.ONNXMiniLMEmbedder, "_ensure_model", fail_onnx)
+        monkeypatch.setattr("httpx.get", fail_ollama)
+
+        embedder = embeddings.get_embedder()
+        assert isinstance(embedder, embeddings.TFIDFEmbedder)
+        assert attempts["count"] <= 1
+
     def test_tfidf_embed(self):
         from clawed.agent_core.memory.embeddings import get_embedder
         embedder = get_embedder()


### PR DESCRIPTION
## Summary
- make memory embedder selection fall back instead of returning a broken ONNX embedder when model download/cache setup fails
- remember ONNX unavailability for the current process to avoid repeated Hugging Face retries after 429s
- add a regression test for the ONNX-unavailable path

## Verification
- `ruff check clawed/agent_core/memory/embeddings.py tests/test_memory.py`
- `python -m pytest tests/test_memory.py::TestEmbeddingProvider::test_falls_back_when_onnx_model_unavailable -q`
- `python -m pytest tests/test_memory.py::TestEmbeddingProvider -q`
- `python -m pytest tests/test_better_memory.py::TestEpisodicMemoryHelpers tests/test_memory.py::TestEpisodicMemory -q`
- `python -m pytest tests/test_better_memory.py tests/test_closed_loop.py tests/test_curriculum_kb.py tests/test_deep_research.py tests/test_knowledge_graph.py tests/test_memory.py tests/test_session_compress.py tests/test_tool_registry.py -q`

Fixes the latest main CI failure caused by Hugging Face HTTP 429s while fetching `sentence-transformers/all-MiniLM-L6-v2`.