### PR TITLE
Funnel: route Claw-ED's reach (~83k installs) into Teacher HQ

### DIFF
--- a/clawed/onboarding.py
+++ b/clawed/onboarding.py
@@ -869,7 +869,7 @@ def run_setup_wizard(reset: bool = False) -> AppConfig:
             "  [bold]clawed chat[/bold]                                  -- Start an interactive session\n"
             "  [bold]clawed lesson \"Topic\" -g 8 -s \"Subject\"[/bold]  -- Generate a lesson\n"
             "  [bold]clawed serve[/bold]                                 -- Launch the web dashboard\n"
-            "  [bold]clawed setup --reset[/bold]                         -- Re-run this wizard anytime",
+            "  [bold]clawed setup --reset[/bold]                         -- Re-run this wizard anytime\n\n[dim]Know a teacher who wants the lessons without the terminal? The done-for-you version is at [bold]macxlabs.app/teacherhq?src=clawed-cli[/bold].[/dim]",
             title="[bold green]\u2705 Ready[/bold green]",
             border_style="green",
             padding=(1, 2),
@@ -1029,7 +1029,7 @@ def _run_onboarding_legacy() -> AppConfig:
             "  [bold]clawed chat[/bold]         \u2014 Start an interactive session\n"
             "  [bold]clawed ingest <path>[/bold] \u2014 Feed me your lesson plans\n"
             "  [bold]clawed serve[/bold]         \u2014 Launch the web dashboard\n\n"
-            "[dim]Tip: Run [bold]clawed ingest <path>[/bold] anytime to add more materials.[/dim]",
+            "[dim]Tip: Run [bold]clawed ingest <path>[/bold] anytime to add more materials.[/dim]\n\n[dim]Know a teacher who wants the lessons without the terminal? The done-for-you version is at [bold]macxlabs.app/teacherhq?src=clawed-cli[/bold].[/dim]",
             title="[bold green]\u2705 Ready[/bold green]",
             border_style="green",
             padding=(1, 2),

--- a/clawed/onboarding.py
+++ b/clawed/onboarding.py
@@ -869,7 +869,9 @@ def run_setup_wizard(reset: bool = False) -> AppConfig:
             "  [bold]clawed chat[/bold]                                  -- Start an interactive session\n"
             "  [bold]clawed lesson \"Topic\" -g 8 -s \"Subject\"[/bold]  -- Generate a lesson\n"
             "  [bold]clawed serve[/bold]                                 -- Launch the web dashboard\n"
-            "  [bold]clawed setup --reset[/bold]                         -- Re-run this wizard anytime\n\n[dim]Know a teacher who wants the lessons without the terminal? The done-for-you version is at [bold]macxlabs.app/teacherhq?src=clawed-cli[/bold].[/dim]",
+            "  [bold]clawed setup --reset[/bold]                         -- Re-run this wizard anytime\n\n"
+            "[dim]Know a teacher who wants the lessons without the terminal? "
+            "The done-for-you version is at [bold]macxlabs.app/teacherhq?src=clawed-cli[/bold].[/dim]",
             title="[bold green]\u2705 Ready[/bold green]",
             border_style="green",
             padding=(1, 2),
@@ -1029,7 +1031,9 @@ def _run_onboarding_legacy() -> AppConfig:
             "  [bold]clawed chat[/bold]         \u2014 Start an interactive session\n"
             "  [bold]clawed ingest <path>[/bold] \u2014 Feed me your lesson plans\n"
             "  [bold]clawed serve[/bold]         \u2014 Launch the web dashboard\n\n"
-            "[dim]Tip: Run [bold]clawed ingest <path>[/bold] anytime to add more materials.[/dim]\n\n[dim]Know a teacher who wants the lessons without the terminal? The done-for-you version is at [bold]macxlabs.app/teacherhq?src=clawed-cli[/bold].[/dim]",
+            "[dim]Tip: Run [bold]clawed ingest <path>[/bold] anytime to add more materials.[/dim]\n\n"
+            "[dim]Know a teacher who wants the lessons without the terminal? "
+            "The done-for-you version is at [bold]macxlabs.app/teacherhq?src=clawed-cli[/bold].[/dim]",
             title="[bold green]\u2705 Ready[/bold green]",
             border_style="green",
             padding=(1, 2),

--- a/docs/index.html
+++ b/docs/index.html
@@ -385,6 +385,23 @@ footer a:hover { color: var(--text-bright); }
 </section>
 
 <!-- ── Install ────────────────────────────────────── -->
+<!-- For teachers who don't code -->
+<section id="for-teachers" style="background:var(--bg-alt);border:1px solid var(--border);border-radius:6px;padding:1.25rem 1.5rem;margin:1.5rem 0;">
+  <h2 style="margin-top:0;">Don't want the command line?</h2>
+  <p style="margin-bottom:0.6rem;">
+    Claw-ED is a developer tool. If you're a teacher who just wants the lessons &mdash; or you
+    know a colleague who does &mdash; there's a done-for-you version: ready-to-run AP &amp; Regents
+    review packs, no install required.
+  </p>
+  <p style="margin:0.6rem 0;">
+    <a href="https://macxlabs.app/teacherhq/?src=clawed-landing"><strong>Get the done-for-you version &rarr; Teacher HQ</strong></a>
+  </p>
+  <p style="font-size:0.85rem;color:var(--text-muted);margin-bottom:0;">
+    A hosted, no-terminal version of Claw-ED is in the works &mdash;
+    <a href="https://macxlabs.app/?src=clawed-landing-hosted">see what MacxLabs is building &rarr;</a>
+  </p>
+</section>
+
 <section id="install">
   <h2>Install</h2>
   <div class="install-block">


### PR DESCRIPTION
## Why
Claw-ED has **~83k PyPI downloads + 50 stars + AI-assistant referrals** — real reach — but **0% of it was captured**. The landing page and CLI's only CTAs sent people back to GitHub. There was no funnel attached to the thing people actually use.

## What
- **`docs/index.html`** — a theme-aware *"Don't want the command line?"* section that routes teacher visitors to the done-for-you **Teacher HQ** (`?src=clawed-landing`) + a "hosted version in the works" link. Uses the page's existing CSS vars (`--bg-alt`/`--border`/`--text-muted`) so it respects light/dark.
- **`clawed/onboarding.py`** — one tasteful line on the setup-complete panel (both onboarding paths), pointing teachers who don't code to Teacher HQ (`?src=clawed-cli`). Seen once per user, not nagging.

## Notes
- **Additive only** — nothing removed, fully reversible.
- **Tracked `?src` tags** so we can measure whether the install base actually converts.
- Next: wire an email capture once a provider is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)