### PR TITLE
fix(memory): stateless fixed-dim TF-IDF fallback (silent embedding rot + search crash)

### DIFF
--- a/clawed/agent_core/memory/curriculum_kb.py
+++ b/clawed/agent_core/memory/curriculum_kb.py
@@ -511,7 +511,9 @@ class CurriculumKB:
             embeddings.append(vec)
 
         # Pad to same dimension if needed (mixed embedder compatibility)
-        max_dim = max(len(e) for e in embeddings)
+        # Include the query length: a variable-dim embedder can produce a
+        # query longer than every stored doc, which previously crashed matmul.
+        max_dim = max(max((len(e) for e in embeddings), default=0), len(q))
         if len(q) < max_dim:
             q = np.pad(q, (0, max_dim - len(q)))
         matrix = np.zeros((len(embeddings), max_dim), dtype=np.float32)

--- a/clawed/agent_core/memory/embeddings.py
+++ b/clawed/agent_core/memory/embeddings.py
@@ -10,6 +10,7 @@ Produces 384-dimensional dense vectors — compact, fast, high quality.
 """
 from __future__ import annotations
 
+import hashlib
 import logging
 import math
 import os
@@ -256,16 +257,17 @@ def _simple_stem(word: str) -> str:
 
 
 class TFIDFEmbedder:
-    """TF-IDF with bigrams — no dependencies, always available.
+    """Hashing term-frequency embedder — no dependencies, always available.
 
-    Vocabulary capped at 512 to keep vectors small in SQLite.
+    Tokens are hashed into a fixed DIM-dimensional space (the "hashing trick"),
+    so the embedder is stateless and deterministic across processes: vectors are
+    always the same length and embeddings stored in the KB stay comparable after
+    a restart. (The previous version grew a per-instance vocabulary that was
+    never persisted, so stored vectors silently rotted between runs and could
+    crash the search matmul when a query was longer than the indexed docs.)
     """
 
-    MAX_VOCAB = 512
-
-    def __init__(self) -> None:
-        self._vocab: dict[str, int] = {}
-        self._next_idx = 0
+    DIM = 512
 
     @staticmethod
     def _tokenize(text: str) -> list[str]:
@@ -277,20 +279,16 @@ class TFIDFEmbedder:
         ]
         return stemmed + bigrams
 
+    @staticmethod
+    def _bucket(token: str) -> int:
+        # Stable across processes (Python's built-in hash() is salted per run).
+        digest = hashlib.blake2b(token.encode("utf-8"), digest_size=8).digest()
+        return int.from_bytes(digest, "big") % TFIDFEmbedder.DIM
+
     def embed(self, text: str) -> list[float]:
-        tokens = self._tokenize(text)
-        for t in tokens:
-            if t not in self._vocab and self._next_idx < self.MAX_VOCAB:
-                self._vocab[t] = self._next_idx
-                self._next_idx += 1
-        dim = min(len(self._vocab), self.MAX_VOCAB)
-        if dim == 0:
-            return [0.0]
-        vec = [0.0] * dim
-        for t in tokens:
-            idx = self._vocab.get(t)
-            if idx is not None and idx < dim:
-                vec[idx] += 1.0
+        vec = [0.0] * self.DIM
+        for t in self._tokenize(text):
+            vec[self._bucket(t)] += 1.0
         norm = math.sqrt(sum(x * x for x in vec)) or 1.0
         return [x / norm for x in vec]
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -83,6 +83,27 @@ class TestEmbeddingProvider:
         assert isinstance(embedder, embeddings.TFIDFEmbedder)
         assert attempts["count"] <= 1
 
+    def test_tfidf_fixed_dimension(self):
+        # Vectors must be a fixed length regardless of content, so the KB's
+        # similarity matmul never hits a dimension mismatch.
+        from clawed.agent_core.memory.embeddings import TFIDFEmbedder
+
+        e = TFIDFEmbedder()
+        vec_short = e.embed("cat")
+        vec_long = e.embed("the quick brown fox jumps over the lazy sleeping dog again")
+        assert len(vec_short) == len(vec_long)
+
+    def test_tfidf_token_index_independent_of_history(self):
+        # A token must map to the same dimension no matter what was embedded
+        # before it, or stored vectors become meaningless across processes.
+        from clawed.agent_core.memory.embeddings import TFIDFEmbedder
+
+        primed = TFIDFEmbedder()
+        primed.embed("alpha beta gamma delta epsilon")
+        v_primed = primed.embed("war")
+        v_fresh = TFIDFEmbedder().embed("war")
+        assert v_primed == v_fresh
+
     def test_tfidf_embed(self):
         from clawed.agent_core.memory.embeddings import get_embedder
         embedder = get_embedder()


### PR DESCRIPTION
## The lead
Merging the ONNX fallback (#5) was correct, but it exposed a **latent bug** in the TF-IDF fallback that was previously masked (the broken ONNX path crashed first). Chasing it down, the matmul crash turned out to be the *visible tip* of a worse, silent bug.

## Root cause
`TFIDFEmbedder` built a **per-instance vocabulary that grew per call and was never persisted**. Two consequences:
1. **Variable-length vectors** → the KB search matmul (`curriculum_kb._search_numpy`) crashed when a query embedded *after* the docs picked up new words and became longer than the stored doc vectors (`size 50 != 47`).
2. **Non-deterministic across processes** (worse) → a fresh process starts with an empty vocab, so a stored doc-vector (`{civil:0, war:1…}`) and a new query-vector (`{what:0, caused:1…}`) live in **different index spaces**. Stored embeddings silently rot between runs whenever the ONNX model isn't present — wrong search results, no error.

## Fix
- **`embeddings.py`** — replace the growing-vocab TF-IDF with the **hashing trick**: tokens are hashed (`blake2b`, stable across processes — *not* Python's per-run-salted `hash()`) into a **fixed 512-dim** space. Stateless, deterministic, always the same length. stdlib only, no new deps.
- **`curriculum_kb.py`** — include the query length in the search `max_dim` (defensive, for genuinely mixed-dim DBs, e.g. ONNX-384 + TF-IDF-512).

## Tests
Two **deterministic** regression tests in `test_memory.py`, each **verified to fail on the old embedder and pass on the new**:
- `test_tfidf_fixed_dimension` — vectors are a fixed length regardless of content.
- `test_tfidf_token_index_independent_of_history` — a token maps to the same dimension no matter what was embedded before it.

(My first attempt tested through the KB and *passed on the buggy code* — the KB swallows the matmul crash in a fallback — so I moved the tests down to the embedder where the bug actually lives.)

Full `test_memory` + `test_curriculum_kb` suites pass (29); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)