### PR TITLE
release: v6.18.2026

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v6.18.2026 — 2026-06-18
+
+### Fixed — Memory and Embeddings
+
+- The local TF-IDF fallback embedder is now stateless and deterministic
+  (feature hashing into a fixed 512-dimensional space). Previously it grew a
+  per-instance vocabulary that was never persisted, so curriculum-search
+  embeddings silently became incompatible across process restarts and could
+  crash the search matmul when a query was longer than the indexed documents.
+- `get_embedder()` falls back cleanly to the TF-IDF embedder when the ONNX
+  MiniLM model cannot be downloaded, instead of returning a non-functional one.
+- Curriculum KB search pads to the larger of the query/document dimension for
+  robustness with mixed-dimension stores.
+
+### Changed
+
+- The landing page and first-run setup now point teachers who don't use the
+  command line to the hosted, done-for-you option.
+
 ## v5.15.2026 — 2026-05-15
 
 ### Hardened — Filesystem Boundaries and Release Trust

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An open-source CLI agent that generates complete lesson bundles — plans, hando
 Claw-ED is maintained as part of [MacxLabs](https://macxlabs.app/?src=github-claw-ed-readme). Teaching AP or Regents? We also build [Review Arcade Teacher HQ](https://macxlabs.app/teacherhq/?src=github-claw-ed-readme) — ready-to-run review-week sprints, made by a fellow teacher. If Claw-ED saves you prep time, you can also [support the project](https://macxlabs.app/support/?src=github-claw-ed-readme).
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-v5.15.2026-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-v6.18.2026-blue" alt="Version">
   <a href="https://pypi.org/project/clawed/"><img src="https://img.shields.io/pypi/v/clawed?color=blue" alt="PyPI"></a>
   <a href="https://pypi.org/project/clawed/"><img src="https://img.shields.io/pypi/pyversions/clawed" alt="Python"></a>
   <a href="https://github.com/SirhanMacx/Claw-ED/actions/workflows/ci.yml"><img src="https://github.com/SirhanMacx/Claw-ED/actions/workflows/ci.yml/badge.svg" alt="CI"></a>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clawed"
-version = "5.15.2026"
+version = "6.18.2026"
 description = "Your AI co-teacher. Generate lessons, games, slides, and assessments from your terminal. Learns your teaching voice, aligns to your state standards, and works with any LLM provider."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump to **6.18.2026**. Ships the stateless fixed-dim TF-IDF embedder (#8), the ONNX fallback (#5), and the Teacher HQ funnel (#7). Tag `v6.18.2026` after merge to publish to PyPI.