### PR TITLE
v6.19.2026 — surface optional support funnel at CLI + landing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v6.19.2026 — 2026-06-19
+
+### Added — Optional support funnel at CLI + landing
+
+- Surfaced an optional, free-forever-respecting "support the project"
+  link (macxlabs.app/support) at both `clawed setup` completion panels
+  and on the landing page (support section + footer). The support rail
+  offers recurring monthly tiers; all links carry `?src` tags for
+  conversion measurement. No paywall — Claw-ED remains free.
+
 ## v6.18.2026 — 2026-06-18
 
 ### Fixed — Memory and Embeddings

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An open-source CLI agent that generates complete lesson bundles — plans, hando
 Claw-ED is maintained as part of [MacxLabs](https://macxlabs.app/?src=github-claw-ed-readme). Teaching AP or Regents? We also build [Review Arcade Teacher HQ](https://macxlabs.app/teacherhq/?src=github-claw-ed-readme) — ready-to-run review-week sprints, made by a fellow teacher. If Claw-ED saves you prep time, you can also [support the project](https://macxlabs.app/support/?src=github-claw-ed-readme).
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-v6.18.2026-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-v6.19.2026-blue" alt="Version">
   <a href="https://pypi.org/project/clawed/"><img src="https://img.shields.io/pypi/v/clawed?color=blue" alt="PyPI"></a>
   <a href="https://pypi.org/project/clawed/"><img src="https://img.shields.io/pypi/pyversions/clawed" alt="Python"></a>
   <a href="https://github.com/SirhanMacx/Claw-ED/actions/workflows/ci.yml"><img src="https://github.com/SirhanMacx/Claw-ED/actions/workflows/ci.yml/badge.svg" alt="CI"></a>

--- a/clawed/onboarding.py
+++ b/clawed/onboarding.py
@@ -870,7 +870,9 @@ def run_setup_wizard(reset: bool = False) -> AppConfig:
             "  [bold]clawed lesson \"Topic\" -g 8 -s \"Subject\"[/bold]  -- Generate a lesson\n"
             "  [bold]clawed serve[/bold]                                 -- Launch the web dashboard\n"
             "  [bold]clawed setup --reset[/bold]                         -- Re-run this wizard anytime\n\n"
-            "[dim]Know a teacher who wants the lessons without the terminal? "
+            "[dim]❤️  Claw-ED is free forever. If it saves you prep time, you can "
+            "[link=https://macxlabs.app/support?src=clawed-cli]support the project[/link]. "
+            "Know a teacher who wants the lessons without the terminal? "
             "The done-for-you version is at [bold]macxlabs.app/teacherhq?src=clawed-cli[/bold].[/dim]",
             title="[bold green]\u2705 Ready[/bold green]",
             border_style="green",
@@ -1032,7 +1034,9 @@ def _run_onboarding_legacy() -> AppConfig:
             "  [bold]clawed ingest <path>[/bold] \u2014 Feed me your lesson plans\n"
             "  [bold]clawed serve[/bold]         \u2014 Launch the web dashboard\n\n"
             "[dim]Tip: Run [bold]clawed ingest <path>[/bold] anytime to add more materials.[/dim]\n\n"
-            "[dim]Know a teacher who wants the lessons without the terminal? "
+            "[dim]❤️  Claw-ED is free forever. If it saves you prep time, you can "
+            "[link=https://macxlabs.app/support?src=clawed-cli]support the project[/link]. "
+            "Know a teacher who wants the lessons without the terminal? "
             "The done-for-you version is at [bold]macxlabs.app/teacherhq?src=clawed-cli[/bold].[/dim]",
             title="[bold green]\u2705 Ready[/bold green]",
             border_style="green",

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,7 +33,7 @@
   "applicationCategory": "EducationalApplication",
   "operatingSystem": "macOS, Windows, Linux",
   "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
-  "softwareVersion": "5.15.2026",
+  "softwareVersion": "6.19.2026",
   "author": {
     "@type": "Organization",
     "name": "Claw-ED",
@@ -647,6 +647,14 @@ pytest</pre>
     <li>Documentation and examples</li>
     <li>Testing with different AI providers and models</li>
   </ul>
+
+  <h3>Support the project</h3>
+  <p>
+    Claw-ED is free and open-source, and always will be. If it saves you prep time and
+    you'd like to help cover its development, you can
+    <a href="https://macxlabs.app/support/?src=clawed-landing">support the project</a>.
+    Entirely optional &mdash; thank you. &#10084;&#65039;
+  </p>
 </section>
 
 <!-- ── Footer ──────────────────────────────────────── -->
@@ -654,6 +662,7 @@ pytest</pre>
   <p>
     <a href="https://github.com/SirhanMacx/Claw-ED">GitHub</a> &middot;
     <a href="https://pypi.org/project/clawed/">PyPI</a> &middot;
+    <a href="https://macxlabs.app/support/?src=clawed-landing-footer">Support</a> &middot;
     <a href="https://sirhanmacx.github.io/Claw-STU/">Claw-STU</a> &middot;
     <a href="GETTING_STARTED.html">Getting Started</a> &middot;
     <a href="FAQ.html">FAQ</a> &middot;
@@ -661,7 +670,7 @@ pytest</pre>
     <a href="https://github.com/SirhanMacx/Claw-ED/discussions">Discussions</a>
   </p>
   <p style="margin-top: 0.5rem;">
-    MIT License &middot; v5.15.2026
+    MIT License &middot; v6.19.2026
   </p>
 </footer>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clawed"
-version = "6.18.2026"
+version = "6.19.2026"
 description = "Your AI co-teacher. Generate lessons, games, slides, and assessments from your terminal. Learns your teaching voice, aligns to your state standards, and works with any LLM provider."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Surfaces an optional, free-forever-respecting **support the project** ask (recurring Stripe rail at macxlabs.app/support) at the two surfaces organic traffic actually lands:

- **CLI**: merged into the existing `clawed setup` Teacher HQ line at both completion panels (one tasteful block, not two stacked promos)
- **Landing**: a *Support the project* section + a footer link

All links carry `?src` tags (`clawed-cli` / `clawed-landing`) so conversion is measurable in the KV funnel. No paywall — Claw-ED stays free. Bumps version 6.18.2026 → 6.19.2026 (badge, pyproject, JSON-LD, footer, CHANGELOG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)