### PR TITLE
v6.19.2026.2 — deck density + title-layout fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v6.19.2026.2 — 2026-06-19
+
+### Fixed — Lesson deck density + title-slide layout (real-content fixes)
+
+- A real generated lesson exposed slide types the fixtures missed: the station
+  overview dumped every station's full directions (~105 words/slide), exit
+  tickets ran long, long source titles bloated headers. Capped so even a
+  content-rich deck stays ~18 words/slide (max ~30).
+- Fixed the title slide: long lesson names auto-shrink (42/34/28pt) and the
+  meta/objective reposition with clearance instead of overlapping the title.
+
 ## v6.19.2026.1 — 2026-06-19
 
 ### Improved — Lesson slide decks (sparse, image-forward, exemplar-matched)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An open-source CLI agent that generates complete lesson bundles — plans, hando
 Claw-ED is maintained as part of [MacxLabs](https://macxlabs.app/?src=github-claw-ed-readme). Teaching AP or Regents? We also build [Review Arcade Teacher HQ](https://macxlabs.app/teacherhq/?src=github-claw-ed-readme) — ready-to-run review-week sprints, made by a fellow teacher. If Claw-ED saves you prep time, you can also [support the project](https://macxlabs.app/support/?src=github-claw-ed-readme).
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-v6.19.2026.1-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-v6.19.2026.2-blue" alt="Version">
   <a href="https://pypi.org/project/clawed/"><img src="https://img.shields.io/pypi/v/clawed?color=blue" alt="PyPI"></a>
   <a href="https://pypi.org/project/clawed/"><img src="https://img.shields.io/pypi/pyversions/clawed" alt="Python"></a>
   <a href="https://github.com/SirhanMacx/Claw-ED/actions/workflows/ci.yml"><img src="https://github.com/SirhanMacx/Claw-ED/actions/workflows/ci.yml/badge.svg" alt="CI"></a>

--- a/clawed/compile_slides.py
+++ b/clawed/compile_slides.py
@@ -287,7 +287,7 @@ def _slide_title(slide: Any, prs_width: Any, text: str,
         slide,
         left=Inches(MARGIN_IN), top=Inches(TITLE_TOP_IN),
         width=prs_width - Inches(2 * MARGIN_IN), height=Inches(TITLE_H_IN),
-        text=_short(text, words=10),
+        text=_short(text, words=7),
         font_size=font_size, bold=True,
         hex_color=hex_color, align_center=align_center,
         word_wrap=False,
@@ -310,18 +310,22 @@ def _build_title_slide(prs: Presentation, master: MasterContent) -> None:
     W = prs.slide_width  # noqa: N806
     slide = _add_slide(prs)
 
+    # Auto-shrink the title for long generated lesson names so it stays ~2 lines
+    # and never overruns the meta/objective lines below it.
+    title = master.title or ""
+    title_size = 42 if len(title) <= 38 else (34 if len(title) <= 66 else 28)
     _textbox(
         slide,
-        left=Inches(0.6), top=Inches(1.5),
-        width=W - Inches(1.2), height=Inches(1.4),
-        text=master.title,
-        font_size=42, bold=True,
+        left=Inches(0.6), top=Inches(1.15),
+        width=W - Inches(1.2), height=Inches(2.05),
+        text=title,
+        font_size=title_size, bold=True,
         hex_color=_C_TERRACOTTA, align_center=True,
     )
     meta = f"{master.subject}  |  Grade {master.grade_level}  |  {master.duration_minutes} min"
     _textbox(
         slide,
-        left=Inches(0.6), top=Inches(3.0),
+        left=Inches(0.6), top=Inches(3.5),
         width=W - Inches(1.2), height=Inches(0.5),
         text=meta,
         font_size=18, bold=True,
@@ -329,8 +333,8 @@ def _build_title_slide(prs: Presentation, master: MasterContent) -> None:
     )
     _textbox(
         slide,
-        left=Inches(0.6), top=Inches(3.7),
-        width=W - Inches(1.2), height=Inches(1.2),
+        left=Inches(0.6), top=Inches(4.25),
+        width=W - Inches(1.2), height=Inches(1.0),
         text=f"Objective: {_short(master.objective, words=10)}",
         font_size=16,
         hex_color=_C_BODY, align_center=True,
@@ -474,7 +478,7 @@ def _build_source_slides(prs: Presentation, master: MasterContent,
 
     for ps in master.primary_sources:
         slide = _add_slide(prs)
-        _slide_title(slide, W, f"Source: {ps.title}", hex_color=_C_TERRACOTTA)
+        _slide_title(slide, W, f"Source: {_short(ps.title, words=6)}", hex_color=_C_TERRACOTTA)
 
         has_image = bool(ps.image_spec and ps.image_spec in images)
         text_w = Inches(TEXT_PANEL_W_IN) if has_image else Inches(FULL_TEXT_W_IN)
@@ -605,18 +609,20 @@ def _build_station_slide(prs: Presentation, master: MasterContent) -> None:
             top=top_offset,
             width=col_w - Inches(0.1),
             height=Inches(0.8),
-            text=_short(station.title, words=8),
+            text=_short(station.title, words=5),
             font_size=18, bold=True,
             hex_color=_C_TERRACOTTA,
         )
+        # Directions live in the handout, not the projected overview slide — keep
+        # this slide to station NAMES only so it stays sparse like the exemplar.
         _textbox(
             slide,
             left=left,
-            top=top_offset + Inches(0.9),
+            top=top_offset + Inches(0.85),
             width=col_w - Inches(0.1),
-            height=Inches(3.4),
-            text=_short(station.student_directions, words=18),
-            font_size=15,
+            height=Inches(0.6),
+            text=f"Station {i + 1}",
+            font_size=14,
             hex_color=_C_BODY,
         )
 
@@ -639,7 +645,7 @@ def _build_exit_ticket_slide(prs: Presentation, master: MasterContent,
         text_w = Inches(TEXT_PANEL_W_IN) if has_image else Inches(FULL_TEXT_W_IN)
 
         stim = getattr(sq, "slide_stimulus", "") or ""
-        stim = _short(stim, words=15) if stim.strip() else _short(sq.stimulus, words=15)
+        stim = _short(stim, words=8) if stim.strip() else _short(sq.stimulus, words=8)
         if stim:
             _textbox(
                 slide,
@@ -653,7 +659,7 @@ def _build_exit_ticket_slide(prs: Presentation, master: MasterContent,
             slide,
             left=Inches(MARGIN_IN), top=Inches(2.7),
             width=text_w, height=Inches(1.8),
-            text=f"Q{i}: {_short(sq.question, words=20)}",
+            text=f"Q{i}: {_short(sq.question, words=13)}",
             font_size=22, bold=True,
             hex_color=_C_TERRACOTTA,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clawed"
-version = "6.19.2026.1"
+version = "6.19.2026.2"
 description = "Your AI co-teacher. Generate lessons, games, slides, and assessments from your terminal. Learns your teaching voice, aligns to your state standards, and works with any LLM provider."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Real-content fixes a fresh GLM lesson exposed: station overview capped (was ~105 words/slide), exit tickets + source titles tightened, deck now ~18 w/slide; title slide auto-shrinks long names instead of overlapping the meta/objective. Full gates green locally (ruff, mypy 270 files, tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)