### PR TITLE
v6.19.2026.3 — image relevance gate + source-slide layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v6.19.2026.3 — 2026-06-19
+
+### Fixed — Lesson deck image relevance + source-slide layout
+
+- Image relevance gate: a noisy slide-title query could make Wikipedia rank an
+  unrelated article first (a real deck once put a Catherine the Great portrait on
+  a Columbus slide). Results are now kept only when the article title shares a
+  meaningful word with the query; otherwise the slide renders text-only. A
+  missing image beats a wrong one.
+- Source slides: long source titles wrapped to two lines and overlapped the
+  attribution. Source title shrinks to one line and the attribution/excerpt drop
+  to clear it; any long section heading now auto-shrinks so it never crowds its
+  body text.
+
 ## v6.19.2026.2 — 2026-06-19
 
 ### Fixed — Lesson deck density + title-slide layout (real-content fixes)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An open-source CLI agent that generates complete lesson bundles — plans, hando
 Claw-ED is maintained as part of [MacxLabs](https://macxlabs.app/?src=github-claw-ed-readme). Teaching AP or Regents? We also build [Review Arcade Teacher HQ](https://macxlabs.app/teacherhq/?src=github-claw-ed-readme) — ready-to-run review-week sprints, made by a fellow teacher. If Claw-ED saves you prep time, you can also [support the project](https://macxlabs.app/support/?src=github-claw-ed-readme).
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-v6.19.2026.2-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-v6.19.2026.3-blue" alt="Version">
   <a href="https://pypi.org/project/clawed/"><img src="https://img.shields.io/pypi/v/clawed?color=blue" alt="PyPI"></a>
   <a href="https://pypi.org/project/clawed/"><img src="https://img.shields.io/pypi/pyversions/clawed" alt="Python"></a>
   <a href="https://github.com/SirhanMacx/Claw-ED/actions/workflows/ci.yml"><img src="https://github.com/SirhanMacx/Claw-ED/actions/workflows/ci.yml/badge.svg" alt="CI"></a>

--- a/clawed/compile_slides.py
+++ b/clawed/compile_slides.py
@@ -283,11 +283,17 @@ def _slide_title(slide: Any, prs_width: Any, text: str,
     """
     from pptx.util import Inches
 
+    capped = _short(text, words=7)
+    # Auto-shrink long headings so they stay on one line and never crowd the body
+    # content positioned just below (mirrors the title-slide auto-shrink).
+    if font_size > 26 and len(capped) > 40:
+        font_size = 28 if len(capped) <= 54 else 26
+
     _textbox(
         slide,
         left=Inches(MARGIN_IN), top=Inches(TITLE_TOP_IN),
         width=prs_width - Inches(2 * MARGIN_IN), height=Inches(TITLE_H_IN),
-        text=_short(text, words=7),
+        text=capped,
         font_size=font_size, bold=True,
         hex_color=hex_color, align_center=align_center,
         word_wrap=False,
@@ -478,14 +484,16 @@ def _build_source_slides(prs: Presentation, master: MasterContent,
 
     for ps in master.primary_sources:
         slide = _add_slide(prs)
-        _slide_title(slide, W, f"Source: {_short(ps.title, words=6)}", hex_color=_C_TERRACOTTA)
+        _slide_title(slide, W, f"Source: {_short(ps.title, words=5)}",
+                     hex_color=_C_TERRACOTTA, font_size=26)
 
         has_image = bool(ps.image_spec and ps.image_spec in images)
         text_w = Inches(TEXT_PANEL_W_IN) if has_image else Inches(FULL_TEXT_W_IN)
 
+        # Attribution + excerpt start low enough to clear a two-line source title.
         _textbox(
             slide,
-            left=Inches(MARGIN_IN), top=Inches(1.2),
+            left=Inches(MARGIN_IN), top=Inches(1.5),
             width=text_w, height=Inches(0.4),
             text=_short(f"{ps.source_type.replace('_', ' ').title()}  |  {ps.attribution}", words=7),
             font_size=13, italic=True,
@@ -497,8 +505,8 @@ def _build_source_slides(prs: Presentation, master: MasterContent,
         if excerpt:
             _textbox(
                 slide,
-                left=Inches(MARGIN_IN), top=Inches(1.8),
-                width=text_w, height=Inches(2.8),
+                left=Inches(MARGIN_IN), top=Inches(2.1),
+                width=text_w, height=Inches(2.4),
                 text=f'"{excerpt}"',
                 font_size=18, italic=True,
                 hex_color=_C_BODY,

--- a/clawed/slide_images.py
+++ b/clawed/slide_images.py
@@ -452,6 +452,59 @@ def _build_search_query(topic: str, subject: str = "") -> str:
     return f"{query_base} {suffix}".strip()
 
 
+# ── Relevance gate ───────────────────────────────────────────────────
+#
+# A noisy slide-title query (e.g. "Two Worlds Collide: What Columbus Found")
+# can make Wikipedia's search rank a topically-unrelated article first — a real
+# deck once landed a Catherine the Great portrait on a Columbus slide. We guard
+# every accepted article by requiring it to share a meaningful word with the
+# query, and SKIP the image otherwise. A MISSING image is better than a WRONG
+# one: the slide compiler renders cleanly as text-only.
+
+# Words that carry no topical signal for the title/query overlap check —
+# includes the generic suffixes the query builder appends ("historical", etc.).
+_RELEVANCE_STOPWORDS = {
+    "the", "a", "an", "of", "in", "on", "for", "and", "to", "is", "are", "what",
+    "he", "she", "they", "his", "her", "their", "with", "from", "that", "this",
+    "was", "were", "by", "as", "at", "it", "its", "into", "how", "why", "who",
+    "when", "where", "two", "one", "new", "found", "wrote", "made", "over",
+    "under", "between", "across", "history", "historical", "primary", "source",
+    "sources", "education", "educational", "diagram", "illustration", "portrait",
+    "literature", "mathematics", "graph", "photo", "image", "picture",
+}
+
+
+def _key_tokens(text: str) -> set[str]:
+    """Significant lower-case tokens (>=4 chars, not stopwords) for relevance."""
+    cleaned = re.sub(r"[^a-zA-Z0-9\s]", " ", text or "").lower()
+    return {w for w in cleaned.split()
+            if len(w) >= 4 and w not in _RELEVANCE_STOPWORDS}
+
+
+def _pick_relevant_article(query: str, results: list[dict[str, Any]]) -> str | None:
+    """Pick the search result whose title best overlaps the query's key tokens.
+
+    Returns the title sharing the MOST meaningful words with the query, or None
+    when no result shares any — signalling the caller to skip the image rather
+    than show an unrelated one. Falls back to the top result only when the query
+    yields no usable tokens to validate against.
+    """
+    if not results:
+        return None
+    q_tokens = _key_tokens(query)
+    if not q_tokens:
+        return str(results[0].get("title") or "") or None
+    best_title: str | None = None
+    best_overlap = 0
+    for r in results:
+        title = str(r.get("title") or "")
+        overlap = len(_key_tokens(title) & q_tokens)
+        if overlap > best_overlap:
+            best_overlap = overlap
+            best_title = title
+    return best_title
+
+
 # ── Source selection ─────────────────────────────────────────────────
 
 
@@ -619,9 +672,16 @@ async def _fetch_wikimedia(
             search_data = search_resp.json()
             search_results = search_data.get("query", {}).get("search", [])
 
-            if search_results:
-                # Take top result — Wikipedia search is good at topic relevance
-                page_title = search_results[0]["title"]
+            # Relevance-gate the search results: skip an article that shares no
+            # meaningful word with the query (a MISSING image beats a WRONG one).
+            page_title = _pick_relevant_article(query, search_results)
+            if not page_title and search_results:
+                logger.info(
+                    "Wikipedia results for '%s' share no key term with the query "
+                    "(top: %r) — skipping to avoid an irrelevant image",
+                    query, [r.get("title") for r in search_results[:3]],
+                )
+            if page_title:
                 img_resp = await client.get(
                     "https://en.wikipedia.org/w/api.php",
                     params={

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clawed"
-version = "6.19.2026.2"
+version = "6.19.2026.3"
 description = "Your AI co-teacher. Generate lessons, games, slides, and assessments from your terminal. Learns your teaching voice, aligns to your state standards, and works with any LLM provider."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Real-deck eyeball fixes: (1) Wikipedia results gated by meaningful-token overlap with the query — kills the Catherine-the-Great-on-a-Columbus-slide class of error, falls back to a clean text-only slide. (2) Source-slide titles no longer overlap the attribution line; long section headings auto-shrink. Full gates green locally (ruff, mypy 270 files, 244 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)