### PR TITLE
v6.19.2026.5 — ship vision images (fix CI mypy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v6.19.2026.5 — 2026-06-19
+
+Ships the v6.19.2026.4 vision-screened lesson images (that build did not publish —
+a strict-mypy CI error). Removes a no-op `style_profile` import that leaked into
+`llm.py` and tripped `mypy --strict` in CI. No runtime change.
+
 ## v6.19.2026.4 — 2026-06-19
 
 ### Added / Fixed — Vision-screened lesson images

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An open-source CLI agent that generates complete lesson bundles — plans, hando
 Claw-ED is maintained as part of [MacxLabs](https://macxlabs.app/?src=github-claw-ed-readme). Teaching AP or Regents? We also build [Review Arcade Teacher HQ](https://macxlabs.app/teacherhq/?src=github-claw-ed-readme) — ready-to-run review-week sprints, made by a fellow teacher. If Claw-ED saves you prep time, you can also [support the project](https://macxlabs.app/support/?src=github-claw-ed-readme).
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-v6.19.2026.4-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-v6.19.2026.5-blue" alt="Version">
   <a href="https://pypi.org/project/clawed/"><img src="https://img.shields.io/pypi/v/clawed?color=blue" alt="PyPI"></a>
   <a href="https://pypi.org/project/clawed/"><img src="https://img.shields.io/pypi/pyversions/clawed" alt="Python"></a>
   <a href="https://github.com/SirhanMacx/Claw-ED/actions/workflows/ci.yml"><img src="https://github.com/SirhanMacx/Claw-ED/actions/workflows/ci.yml/badge.svg" alt="CI"></a>

--- a/clawed/llm.py
+++ b/clawed/llm.py
@@ -630,19 +630,6 @@ class LLMClient:
             except ImportError:
                 pass  # Memory engine not available -- that's fine
 
-            # Inject the teacher's ACTIVE STYLE PROFILE (learned from their
-            # own files via ingest_materials) so every generation — lessons,
-            # assessments, sub packets — matches their real voice. Off-switch:
-            # set_active_profile(None) makes this a no-op.
-            try:
-                from clawed.style_profile import active_prompt_block
-
-                style_ctx = active_prompt_block()
-                if style_ctx:
-                    system = (system + "\n\n" + style_ctx) if system else style_ctx
-            except ImportError:
-                pass  # Style profiles not available -- that's fine
-
             return system
 
     def _detect_subject_from_prompt(self, prompt: str) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clawed"
-version = "6.19.2026.4"
+version = "6.19.2026.5"
 description = "Your AI co-teacher. Generate lessons, games, slides, and assessments from your terminal. Learns your teaching voice, aligns to your state standards, and works with any LLM provider."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
v6.19.2026.4 failed to publish on a strict-mypy CI error: a no-op style_profile import leaked into llm.py via cherry-pick (main's style_profile lacks active_prompt_block; the except-ImportError already swallowed it at runtime). Removed it. Ships the vision-screened image system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)