### PR TITLE
v6.19.2026.6 — block watermarked stock images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v6.19.2026.6 — 2026-06-19
+
+### Fixed — No watermarked stock images in lesson decks
+
+- Block paid stock-photo domains (alamy, getty, shutterstock, istockphoto, ...) at
+  image-fetch time. Web image search returns watermarked stock previews that the
+  vision screen can miss in a small montage thumbnail; now those hosts are rejected
+  before they ever become candidates. License-clean sources (Wikimedia, LoC) pass.
+
 ## v6.19.2026.5 — 2026-06-19
 
 Ships the v6.19.2026.4 vision-screened lesson images (that build did not publish —

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An open-source CLI agent that generates complete lesson bundles — plans, hando
 Claw-ED is maintained as part of [MacxLabs](https://macxlabs.app/?src=github-claw-ed-readme). Teaching AP or Regents? We also build [Review Arcade Teacher HQ](https://macxlabs.app/teacherhq/?src=github-claw-ed-readme) — ready-to-run review-week sprints, made by a fellow teacher. If Claw-ED saves you prep time, you can also [support the project](https://macxlabs.app/support/?src=github-claw-ed-readme).
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-v6.19.2026.5-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-v6.19.2026.6-blue" alt="Version">
   <a href="https://pypi.org/project/clawed/"><img src="https://img.shields.io/pypi/v/clawed?color=blue" alt="PyPI"></a>
   <a href="https://pypi.org/project/clawed/"><img src="https://img.shields.io/pypi/pyversions/clawed" alt="Python"></a>
   <a href="https://github.com/SirhanMacx/Claw-ED/actions/workflows/ci.yml"><img src="https://github.com/SirhanMacx/Claw-ED/actions/workflows/ci.yml/badge.svg" alt="CI"></a>

--- a/clawed/slide_images.py
+++ b/clawed/slide_images.py
@@ -49,6 +49,26 @@ _FETCH_TIMEOUT = 15.0
 # operator explicitly opts in via EDUAGENT_IMAGE_FETCH_ALLOW_INTERNAL=1.
 
 
+# Paid stock-photo sites serve WATERMARKED preview images (an "alamy" / "getty"
+# overlay across the picture) — never usable in a classroom deck, and a licensing
+# problem. We reject them at fetch time so a watermarked image never even becomes a
+# candidate for the vision screen (which can miss a small watermark in a thumbnail).
+_STOCK_PHOTO_HOSTS = (
+    "alamy", "gettyimages", "shutterstock", "istockphoto", "dreamstime",
+    "123rf", "depositphotos", "stock.adobe", "agefotostock", "fotosearch",
+    "bigstock", "canstockphoto", "stockphoto", "stocksy",
+)
+
+
+def _is_stock_photo_url(url: str) -> bool:
+    """True if the URL host is a paid stock-photo site (serves watermarked previews)."""
+    try:
+        host = urlparse(url).netloc.lower()
+    except ValueError:
+        return False
+    return any(s in host for s in _STOCK_PHOTO_HOSTS)
+
+
 def _is_safe_image_url(url: str) -> bool:
     """Return True if ``url`` is safe to fetch as a remote image.
 
@@ -1152,6 +1172,7 @@ async def _fetch_web_scrape(
                     url
                     and url.startswith("http")
                     and not url.endswith(".svg")
+                    and not _is_stock_photo_url(url)
                     and _is_safe_image_url(url)
                 ):
                     image_url = url

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clawed"
-version = "6.19.2026.5"
+version = "6.19.2026.6"
 description = "Your AI co-teacher. Generate lessons, games, slides, and assessments from your terminal. Learns your teaching voice, aligns to your state standards, and works with any LLM provider."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Block paid stock-photo domains (alamy/getty/shutterstock/...) at image fetch so watermarked previews never reach a lesson deck (the vision screen can miss a small watermark in a thumbnail). License-clean sources pass. Full gates green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)